### PR TITLE
fix(env_wrapper): fix warning caused by 'none' string default value in parameters of __init__().

### DIFF
--- a/envs/safety-gymnasium/examples/safety_gym_v2_vision.py
+++ b/envs/safety-gymnasium/examples/safety_gym_v2_vision.py
@@ -21,9 +21,7 @@ import safety_gymnasium
 from gymnasium.utils.save_video import save_video
 
 
-WORKDIR = os.path.abspath('.')
-DIR = os.path.join(WORKDIR, 'omnisafe/envs/safety-gymnasium/examples', 'cached_test_vision_video')
-
+DIR = os.path.join(os.path.dirname(__file__), 'cached_test_vision_video')
 
 def run_random(env_name):
     env = safety_gymnasium.make(env_name)

--- a/envs/safety-gymnasium/examples/safety_gym_v2_vision.py
+++ b/envs/safety-gymnasium/examples/safety_gym_v2_vision.py
@@ -23,6 +23,7 @@ from gymnasium.utils.save_video import save_video
 
 DIR = os.path.join(os.path.dirname(__file__), 'cached_test_vision_video')
 
+
 def run_random(env_name):
     env = safety_gymnasium.make(env_name)
     # env.seed(0)

--- a/envs/safety-gymnasium/tests/test_safety_gym_v2.py
+++ b/envs/safety-gymnasium/tests/test_safety_gym_v2.py
@@ -19,12 +19,15 @@ import helpers
 
 
 @helpers.parametrize(
-    agent_id=['Point', 'Car'], env_id=['Goal', 'Push', 'Button'], level=['0', '1', '2']
+    agent_id=['Point', 'Car'],
+    env_id=['Goal', 'Push', 'Button'],
+    level=['0', '1', '2'],
+    render_mode=['rgb_array', 'depth_array'],
 )
-def test_off_policy(agent_id, env_id, level):
+def test_off_policy(agent_id, env_id, level, render_mode):
     """test_env"""
     env_name = 'Safety' + agent_id + env_id + level + '-v0'
-    env = safety_gymnasium.make(env_name, render_mode='rgb_array')
+    env = safety_gymnasium.make(env_name, render_mode=render_mode)
     obs, _ = env.reset()
     terminled = False
     ep_ret = 0
@@ -45,3 +48,5 @@ def test_off_policy(agent_id, env_id, level):
         obs, reward, cost, terminled, truncated, info = env.step(act)
         ep_ret += reward
         ep_cost += cost
+
+        env.render()

--- a/omnisafe/algos/env_wrapper.py
+++ b/omnisafe/algos/env_wrapper.py
@@ -21,7 +21,7 @@ import torch
 class EnvWrapper:
     """env_wrapper"""
 
-    def __init__(self, env_id, render_mode='none'):
+    def __init__(self, env_id, render_mode=None):
         # check env_id is str
         self.env = safety_gymnasium.make(
             env_id, render_mode=render_mode


### PR DESCRIPTION
…init__().

## Description

Fix warning caused by 'none' string default value in parameters of __init__().
It looks like:
![image](https://user-images.githubusercontent.com/118189931/205491469-012bcca8-2b20-4bc3-88bc-52bcf9fb40d7.png)


## Motivation and Context

Why is this change required? What problem does it solve?
It solves a wrong warning.
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-MARL/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://omnisafe.readthedocs.io/en/latest/developer/contributing.html) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
