### PR TITLE
fix(rollout, exp_grid): fix logdir path conflict

### DIFF
--- a/omnisafe/algorithms/algo_wrapper.py
+++ b/omnisafe/algorithms/algo_wrapper.py
@@ -71,7 +71,7 @@ class AlgoWrapper:
             cfgs.train_cfgs.recurisve_update(self.train_terminal_cfgs)
 
         # the exp_name format is PPO-<SafetyPointGoal1-v0>-
-        exp_name = f'{self.algo}-<{self.env_id}>'
+        exp_name = f'{self.algo}-({self.env_id})'
         cfgs.recurisve_update({'exp_name': exp_name, 'env_id': self.env_id})
         cfgs.train_cfgs.recurisve_update(
             {'epochs': cfgs.train_cfgs.total_steps // cfgs.algo_cfgs.update_cycle}

--- a/omnisafe/algorithms/algo_wrapper.py
+++ b/omnisafe/algorithms/algo_wrapper.py
@@ -70,7 +70,7 @@ class AlgoWrapper:
         if self.train_terminal_cfgs:
             cfgs.train_cfgs.recurisve_update(self.train_terminal_cfgs)
 
-        # the exp_name format is PPO-<SafetyPointGoal1-v0>-
+        # the exp_name format is PPO-(SafetyPointGoal1-v0)-
         exp_name = f'{self.algo}-({self.env_id})'
         cfgs.recurisve_update({'exp_name': exp_name, 'env_id': self.env_id})
         cfgs.train_cfgs.recurisve_update(

--- a/omnisafe/common/experiment_grid.py
+++ b/omnisafe/common/experiment_grid.py
@@ -365,7 +365,7 @@ class ExperimentGrid:
             if parent_dir is None:
                 log_dir = os.path.join('./', 'exp-x', self.name, exp_name, '')
             else:
-                log_dir = os.path.join(dir, self.name, exp_name, '')
+                log_dir = os.path.join(parent_dir, self.name, exp_name, '')
             var['logger_cfgs'] = {'log_dir': log_dir}
             results.append(pool.submit(thunk, idx, var['algo'], var['env_id'], var))
         pool.shutdown()

--- a/omnisafe/common/experiment_grid.py
+++ b/omnisafe/common/experiment_grid.py
@@ -292,7 +292,7 @@ class ExperimentGrid:
         return new_variants
 
     # pylint: disable-next=too-many-locals
-    def run(self, thunk, num_pool=1, log_dir=None, is_test=False):
+    def run(self, thunk, num_pool=1, parent_dir=None, is_test=False):
         r"""Run each variant in the grid with function 'thunk'.
 
         Note: 'thunk' must be either a callable function, or a string. If it is
@@ -362,8 +362,10 @@ class ExperimentGrid:
             print('current_config', var)
             exp_name = '_'.join([k + '_' + str(v) for k, v in var.items()])
             exp_names.append(exp_name)
-            if log_dir is None:
+            if parent_dir is None:
                 log_dir = os.path.join('./', 'exp-x', self.name, exp_name, '')
+            else:
+                log_dir = os.path.join(dir, self.name, exp_name, '')
             var['logger_cfgs'] = {'log_dir': log_dir}
             results.append(pool.submit(thunk, idx, var['algo'], var['env_id'], var))
         pool.shutdown()


### PR DESCRIPTION
## Description

1. Explicitly distinguish the terminated and truncated.
2. Fix the parent path named by the config in exp_grid.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-MARL/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://omnisafe.readthedocs.io/en/latest/developer/contributing.html) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**)
- [ ] I have checked the code using `make lint`. (**required**)
- [ ] I have ensured `make test` pass. (**required**)
