### PR TITLE
fix(onpolicy_adapter): fix the calculation of last state value

### DIFF
--- a/omnisafe/adapter/onpolicy_adapter.py
+++ b/omnisafe/adapter/onpolicy_adapter.py
@@ -84,15 +84,17 @@ class OnPolicyAdapter(OnlineAdapter):
             epoch_end = step >= steps_per_epoch - 1
             for idx, (done, time_out) in enumerate(zip(terminated, truncated)):
                 if epoch_end or done or time_out:
-                    if (epoch_end or time_out) and not done:
+                    if not done:
                         if epoch_end:
                             logger.log(
                                 f'Warning: trajectory cut off when rollout by epoch at {self._ep_len[idx]} steps.'
                             )
-                        _, last_value_r, last_value_c, _ = agent.step(obs[idx])
+                            _, last_value_r, last_value_c, _ = agent.step(obs[idx])
+                        if time_out:
+                            _, last_value_r, last_value_c, _ = agent.step(info[idx]['final observation'])
                         last_value_r = last_value_r.unsqueeze(0)
                         last_value_c = last_value_c.unsqueeze(0)
-                    elif done:
+                    else:
                         last_value_r = torch.zeros(1)
                         last_value_c = torch.zeros(1)
 


### PR DESCRIPTION
Co-authored-by: borong <borongzh@gmail.com>
Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
Co-authored-by: ruiyang sun <rockmagma02@gmail.com>
Co-authored-by: zmsn-2077 <73586554+zmsn-2077@users.noreply.github.com>
Co-authored-by: friedmainfunction <73703265+friedmainfunction@users.noreply.github.com>
Co-authored-by: Gaiejj <524339208@qq.com>
Co-authored-by: zmsn-2077 <jiamg.ji@gmail.com>
Co-authored-by: Ruiyang Sun <rockmagma02@gmail.com>
Co-authored-by: Jiayi Zhou <108712610+Gaiejj@users.noreply.github.com>
Co-authored-by: 1Asan <99461435+1Asan@users.noreply.github.com>
fix(algo): fix no return in algo_wrapper::learn (#122)
fix(logger, wrapper): support csv file and velocity tasks (#131)
fix typo. (#134)
fix(ppo): fix entropy loss (#135)
fix bugs (#136)
fix: support new config for exp_grid (#142)
fix(rollout, exp_grid): fix logdir path conflict (#145)
fix(on-policy): fix the second order algorithms performance (#147)## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [x] I have raised an issue to propose this change ([required](https://github.com/PKU-MARL/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://omnisafe.readthedocs.io/en/latest/developer/contributing.html) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**)
- [ ] I have checked the code using `make lint`. (**required**)
- [ ] I have ensured `make test` pass. (**required**)
